### PR TITLE
chore: remove target from tsdown

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   entry: 'src/index.tsx',
   format: ['esm'],
-  target: 'node20',
   banner: { js: '#!/usr/bin/env node' },
   external: ['ink', 'react'],
   jsx: 'automatic',


### PR DESCRIPTION
tsdown reads `engines` property in package.json so we don't need to add it

https://tsdown.dev/options/target#default-target-behavior