### PR TITLE
fix: restore keyboard focus after closing action menu

### DIFF
--- a/src/components/FileList/FileList.tsx
+++ b/src/components/FileList/FileList.tsx
@@ -1,5 +1,5 @@
 import { basename } from 'node:path';
-import { Box, Text, useFocus, useInput } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import React, { useEffect, useMemo, useState } from 'react';
 import type {
   ClaudeFileInfo,
@@ -41,7 +41,6 @@ const FileList = React.memo(function FileList({
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const [isMenuMode, setIsMenuMode] = useState(false);
   const [isGroupSelected, setIsGroupSelected] = useState(false);
-  const { isFocused } = useFocus({ autoFocus: true });
 
   // Filtered groups after search (memoized)
   const filteredGroups = useMemo(() => {
@@ -229,7 +228,7 @@ const FileList = React.memo(function FileList({
         onSearchQueryChange?.(searchQuery + input);
       }
     },
-    { isActive: isFocused && !isMenuMode },
+    { isActive: !isMenuMode },
   );
 
   return (
@@ -281,7 +280,6 @@ const FileList = React.memo(function FileList({
                         !isGroupSelected &&
                         groupIndex === currentGroupIndex &&
                         fileIndex === currentFileIndex &&
-                        isFocused &&
                         !isMenuMode
                       }
                     />


### PR DESCRIPTION
## Summary
- Fixed keyboard focus loss issue when returning from action menu to file list
- Removed dependency on React Ink's `useFocus` hook which was causing the focus problem
- Simplified focus management by using only `isMenuMode` state to control input handling

## Problem
When users opened the action menu (by pressing Enter on a file) and then closed it (by pressing ESC), the keyboard input would stop working. This was because the `useFocus` hook in React Ink doesn't automatically restore focus once it's lost.

## Solution
Instead of relying on the `isFocused` state from `useFocus`, the input handling now only checks the `isMenuMode` state. This ensures that:
- When menu is open (`isMenuMode: true`), FileList doesn't capture input
- When menu is closed (`isMenuMode: false`), FileList immediately starts capturing input again

## Test plan
- [x] All existing tests pass
- [ ] Manual testing: Open action menu and close it, verify keyboard navigation works
- [ ] Manual testing: Test all navigation keys (arrows, Enter, ESC) after menu close
- [ ] Manual testing: Test search functionality after menu close