### PR TITLE
fix: resolve knip errors in git worktree environments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,19 +26,15 @@
         "bumpp": "^10.2.0",
         "clean-pkg-json": "^1.3.0",
         "concurrently": "^9.2.0",
-        "es-toolkit": "^1.39.5",
         "fs-fixture": "^2.8.1",
         "ink-testing-library": "^4.0.0",
         "knip": "^5.61.3",
         "lefthook": "^1.11.14",
-        "path-type": "^6.0.0",
         "publint": "^0.3.12",
         "ts-pattern": "^5.5.0",
         "tsdown": "^0.12.9",
-        "type-fest": "^4.41.0",
         "typescript": "^5.7.2",
         "vitest": "^3.2.4",
-        "xdg-basedir": "^5.1.0",
       },
     },
   },
@@ -566,8 +562,6 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
-
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
@@ -727,8 +721,6 @@
     "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
 
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignore": ["dist/**", ".git/**"],
-  "ignoreDependencies": ["es-toolkit", "path-type", "type-fest", "xdg-basedir"]
+  "ignoreDependencies": ["lefthook"],
+  "lefthook": false
 }

--- a/package.json
+++ b/package.json
@@ -50,19 +50,15 @@
     "bumpp": "^10.2.0",
     "clean-pkg-json": "^1.3.0",
     "concurrently": "^9.2.0",
-    "es-toolkit": "^1.39.5",
     "fs-fixture": "^2.8.1",
     "ink-testing-library": "^4.0.0",
     "knip": "^5.61.3",
     "lefthook": "^1.11.14",
-    "path-type": "^6.0.0",
     "publint": "^0.3.12",
     "ts-pattern": "^5.5.0",
     "tsdown": "^0.12.9",
-    "type-fest": "^4.41.0",
     "typescript": "^5.7.2",
-    "vitest": "^3.2.4",
-    "xdg-basedir": "^5.1.0"
+    "vitest": "^3.2.4"
   },
   "overrides": {
     "vite": "npm:rolldown-vite@latest"


### PR DESCRIPTION
## Summary

Fixes knip execution errors when running in git worktree environments by disabling the Lefthook plugin.

## Problem

In git worktrees, `.git` is a file (not a directory), causing knip's Lefthook plugin to fail:

```
Error: ENOTDIR: not a directory, lstat '.git/hooks/post-merge'
```

## Root Cause

- Git worktree uses `.git` as a file pointing to the actual git directory
- Knip's Lefthook plugin assumes `.git` is always a directory
- When the plugin tries to access `.git/hooks/*`, it fails with ENOTDIR

## Solution

1. Disable Lefthook plugin in `knip.json`:
   ```json
   {
     "lefthook": false,
     "ignoreDependencies": ["lefthook"]
   }
   ```

2. Also removed unused dependencies discovered during investigation:
   - es-toolkit
   - path-type
   - type-fest
   - xdg-basedir

## Similar Issues

- cocogitto/cocogitto#312 - Git worktree ENOTDIR errors
- Escape-Technologies/mookme#127 - Cannot mkdir .git/hooks in worktree
- vercel/vercel#11876 - Vercel CLI worktree support

## Test Results

- ✅ `bun run knip` - Runs without errors
- ✅ `bun run ci` - All checks pass