### PR TITLE
feat: add support for settings.json configuration files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,9 @@ The tool automatically discovers these file types:
 - **CLAUDE.local.md** → Local overrides (gitignored)  
 - **~/.claude/CLAUDE.md** → Global user configuration
 - **.claude/commands/**/*.md** → Slash command definitions
+- **.claude/settings.json** → Project settings (shared)
+- **.claude/settings.local.json** → Local project settings (gitignored)
+- **~/.claude/settings.json** → User settings (global)
 
 ### TypeScript Configuration
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Claude Code Explorer automatically discovers these configuration files:
 - **CLAUDE.local.md** → Local overrides (gitignored)
 - **~/.claude/CLAUDE.md** → Global user configuration
 - **.claude/commands/**/*.md** → Slash command definitions
+- **.claude/settings.json** → Project settings (shared)
+- **.claude/settings.local.json** → Local project settings (gitignored)
+- **~/.claude/settings.json** → User settings (global)
 
 ## Installation
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -15,6 +15,8 @@ export type ClaudeFileType =
   | 'claude-local-md'
   | 'global-md'
   | 'slash-command'
+  | 'settings-json'
+  | 'settings-local-json'
   | 'unknown';
 
 export type ProjectInfo = {

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -52,6 +52,20 @@ export const detectClaudeFileType = (filePath: string): ClaudeFileType => {
       ],
       () => 'slash-command' as const,
     )
+    .with(
+      [
+        'settings.json',
+        P.when((dir) => dir.endsWith('/.claude') || dir.includes('/.claude/')),
+      ],
+      () => 'settings-json' as const,
+    )
+    .with(
+      [
+        'settings.local.json',
+        P.when((dir) => dir.endsWith('/.claude') || dir.includes('/.claude/')),
+      ],
+      () => 'settings-local-json' as const,
+    )
     .otherwise(() => 'unknown' as const);
 };
 
@@ -257,6 +271,31 @@ if (import.meta.vitest != null) {
     test('should detect slash command files', () => {
       expect(detectClaudeFileType('/project/.claude/commands/deploy.md')).toBe(
         'slash-command',
+      );
+    });
+
+    test('should detect settings.json files', () => {
+      expect(detectClaudeFileType('/project/.claude/settings.json')).toBe(
+        'settings-json',
+      );
+      expect(detectClaudeFileType('/Users/name/.claude/settings.json')).toBe(
+        'settings-json',
+      );
+    });
+
+    test('should detect settings.local.json files', () => {
+      expect(detectClaudeFileType('/project/.claude/settings.local.json')).toBe(
+        'settings-local-json',
+      );
+      expect(
+        detectClaudeFileType('/Users/name/.claude/settings.local.json'),
+      ).toBe('settings-local-json');
+    });
+
+    test('should not detect settings files outside .claude', () => {
+      expect(detectClaudeFileType('/project/settings.json')).toBe('unknown');
+      expect(detectClaudeFileType('/project/settings.local.json')).toBe(
+        'unknown',
       );
     });
   });

--- a/src/components/FileList/FileGroup.test.tsx
+++ b/src/components/FileList/FileGroup.test.tsx
@@ -29,6 +29,8 @@ if (import.meta.vitest) {
         'claude-local-md': 'LOCAL',
         'slash-command': 'COMMAND',
         'global-md': 'GLOBAL',
+        'settings-json': 'SETTINGS',
+        'settings-local-json': 'LOCAL SETTINGS',
         unknown: 'OTHER',
       };
 

--- a/src/components/FileList/FileGroup.tsx
+++ b/src/components/FileList/FileGroup.tsx
@@ -16,6 +16,8 @@ const getGroupLabel = (type: ClaudeFileType): string => {
     .with('claude-local-md', () => 'LOCAL')
     .with('slash-command', () => 'COMMAND')
     .with('global-md', () => 'GLOBAL')
+    .with('settings-json', () => 'SETTINGS')
+    .with('settings-local-json', () => 'LOCAL SETTINGS')
     .with('unknown', () => 'OTHER')
     .exhaustive();
 };
@@ -26,6 +28,8 @@ const getGroupColor = (type: ClaudeFileType): string => {
     .with('claude-local-md', () => 'yellow')
     .with('slash-command', () => 'green')
     .with('global-md', () => 'magenta')
+    .with('settings-json', () => 'cyan')
+    .with('settings-local-json', () => 'yellowBright')
     .with('unknown', () => 'gray')
     .exhaustive();
 };

--- a/src/components/FileList/FileItem.tsx
+++ b/src/components/FileList/FileItem.tsx
@@ -29,6 +29,14 @@ export const FileItem = React.memo(function FileItem({
         label: 'COMMAND',
       }))
       .with('global-md', () => ({ color: 'magenta' as const, label: 'GLOBAL' }))
+      .with('settings-json', () => ({
+        color: 'cyan' as const,
+        label: 'SETTINGS',
+      }))
+      .with('settings-local-json', () => ({
+        color: 'yellowBright' as const,
+        label: 'LOCAL SETTINGS',
+      }))
       .with('unknown', () => ({ color: 'gray' as const, label: 'FILE' }))
       .exhaustive();
   };
@@ -40,6 +48,8 @@ export const FileItem = React.memo(function FileItem({
       .with('claude-local-md', () => '🔒')
       .with('slash-command', () => '⚡')
       .with('global-md', () => '🌐')
+      .with('settings-json', () => '⚙️')
+      .with('settings-local-json', () => '🔧')
       .with('unknown', () => '📄')
       .exhaustive();
   };
@@ -50,13 +60,28 @@ export const FileItem = React.memo(function FileItem({
   const parentDir = basename(dirPath);
 
   // Display name (including parent directory)
-  // Special handling for home directory
-  const displayName =
-    file.type === 'global-md'
-      ? `~/.claude/${fileName}`
-      : file.type === 'slash-command'
-        ? fileName.replace('.md', '') // Remove .md for commands
-        : `${parentDir}/${fileName}`;
+  // Special handling for home directory and settings files
+  const getDisplayName = (): string => {
+    if (file.type === 'global-md') {
+      return `~/.claude/${fileName}`;
+    }
+    if (file.type === 'slash-command') {
+      return fileName.replace('.md', ''); // Remove .md for commands
+    }
+    if (file.type === 'settings-json' || file.type === 'settings-local-json') {
+      // For settings files, show 3 levels: grandparent/parent/filename
+      const parts = file.path.split('/');
+      const claudeIndex = parts.lastIndexOf('.claude');
+      if (claudeIndex > 0 && parts[claudeIndex - 1]) {
+        // Show: project-name/.claude/settings.json
+        return `${parts[claudeIndex - 1]}/.claude/${fileName}`;
+      }
+      return `${parentDir}/${fileName}`;
+    }
+    return `${parentDir}/${fileName}`;
+  };
+
+  const displayName = getDisplayName();
 
   const prefix = isFocused ? '► ' : '  ';
 

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -7,6 +7,17 @@ import type { ClaudeFileInfo } from '../../_types.js';
 import { isBinaryFile } from '../../_utils.js';
 import { MarkdownPreview } from './MarkdownPreview.js';
 
+// Format JSON content for better readability
+const formatJsonContent = (content: string): string => {
+  try {
+    const parsed = JSON.parse(content);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    // If parsing fails, return original content
+    return content;
+  }
+};
+
 type PreviewProps = {
   readonly file?: ClaudeFileInfo | undefined;
 };
@@ -137,6 +148,8 @@ export function Preview({ file }: PreviewProps): React.JSX.Element {
         <Box flexDirection="column" paddingRight={1}>
           {fileName.endsWith('.md') ? (
             <MarkdownPreview content={previewContent} />
+          ) : fileName.endsWith('.json') ? (
+            <Text>{formatJsonContent(previewContent)}</Text>
           ) : (
             <Text>{previewContent}</Text>
           )}

--- a/src/hooks/useFileNavigation.tsx
+++ b/src/hooks/useFileNavigation.tsx
@@ -7,6 +7,7 @@ import type {
   SlashCommandInfo,
 } from '../_types.js';
 import { scanClaudeFiles } from '../claude-md-scanner.js';
+import { scanSettingsJson } from '../settings-json-scanner.js';
 import { scanSlashCommands } from '../slash-command-scanner.js';
 
 // Union type to unify ClaudeFileInfo and SlashCommandInfo
@@ -58,15 +59,23 @@ export function useFileNavigation(
   useEffect(() => {
     // Execute file scan
     const scanOptions = { recursive, path };
-    Promise.all([scanClaudeFiles(scanOptions), scanSlashCommands(scanOptions)])
-      .then(([claudeFiles, slashCommands]) => {
+    Promise.all([
+      scanClaudeFiles(scanOptions),
+      scanSlashCommands(scanOptions),
+      scanSettingsJson(scanOptions),
+    ])
+      .then(([claudeFiles, slashCommands, settingsFiles]) => {
         // Convert slash commands to ClaudeFileInfo format
         const convertedCommands = slashCommands.map(
           convertSlashCommandToFileInfo,
         );
 
-        // Combine both results
-        const allFiles = [...claudeFiles, ...convertedCommands];
+        // Combine all results
+        const allFiles = [
+          ...claudeFiles,
+          ...convertedCommands,
+          ...settingsFiles,
+        ];
 
         // Group files by type
         const groupedFiles = allFiles.reduce<
@@ -95,6 +104,8 @@ export function useFileNavigation(
         const orderedTypes: ClaudeFileType[] = [
           'claude-md',
           'claude-local-md',
+          'settings-json',
+          'settings-local-json',
           'slash-command',
           'global-md',
           'unknown',

--- a/src/settings-json-scanner.ts
+++ b/src/settings-json-scanner.ts
@@ -1,0 +1,202 @@
+import type { Stats } from 'node:fs';
+import type { ClaudeFileInfo, ScanOptions } from './_types.ts';
+import { createClaudeFilePath } from './_types.ts';
+import { detectClaudeFileType } from './_utils.ts';
+import { BaseFileScanner } from './base-file-scanner.ts';
+import { findSettingsJson } from './fast-scanner.ts';
+
+/**
+ * Settings JSON scanner for parsing .claude/project/settings.json files
+ */
+class SettingsJsonScanner extends BaseFileScanner<ClaudeFileInfo> {
+  protected readonly maxFileSize = 1024 * 1024; // 1MB limit for settings files
+  protected readonly fileType = 'settings.json';
+
+  protected async parseContent(
+    filePath: string,
+    content: string,
+    stats: Stats,
+  ): Promise<ClaudeFileInfo | null> {
+    try {
+      // Try to parse JSON to validate it
+      JSON.parse(content);
+
+      // Extract any tags from content (unlikely for JSON but keeping consistency)
+      const tags: string[] = [];
+
+      return {
+        path: createClaudeFilePath(filePath),
+        type: detectClaudeFileType(filePath),
+        size: stats.size,
+        lastModified: stats.mtime,
+        projectInfo: undefined,
+        commands: [],
+        tags,
+      };
+    } catch (error) {
+      console.warn(`Invalid JSON in settings file ${filePath}:`, error);
+      return null;
+    }
+  }
+}
+
+/**
+ * Scan for settings.json files in .claude/project directories
+ */
+export const scanSettingsJson = async (
+  options: ScanOptions = {},
+): Promise<ClaudeFileInfo[]> => {
+  const {
+    path = process.cwd(),
+    recursive = true,
+    includeHidden = false,
+  } = options;
+
+  // Scan specified path
+  const paths = await findSettingsJson({
+    path,
+    recursive,
+    includeHidden,
+  });
+
+  // Also scan global Claude directory if scanning recursively
+  if (recursive) {
+    const { homedir } = await import('node:os');
+    const globalPath = homedir();
+
+    // Only scan home directory if it's different from the current path
+    if (globalPath !== path) {
+      const globalFiles = await findSettingsJson({
+        path: globalPath,
+        recursive: true,
+        includeHidden,
+      });
+      paths.push(...globalFiles);
+    }
+  }
+
+  // Remove duplicates based on file path
+  const uniquePaths: string[] = Array.from(new Set(paths));
+
+  const scanner = new SettingsJsonScanner();
+
+  const results = await Promise.all(
+    uniquePaths.map((path) => scanner.processFile(path)),
+  );
+
+  return results.filter((file): file is ClaudeFileInfo => file !== null);
+};
+
+// InSource tests
+if (import.meta.vitest != null) {
+  const { describe, test, expect } = import.meta.vitest;
+  const { createFixture } = await import('fs-fixture');
+
+  describe('SettingsJsonScanner', () => {
+    test('should parse valid settings.json files', async () => {
+      const scanner = new SettingsJsonScanner();
+
+      const fixture = await createFixture({
+        '.claude': {
+          'settings.json': JSON.stringify({
+            version: '1.0',
+            features: ['feature1', 'feature2'],
+          }),
+        },
+      });
+
+      try {
+        const result = await scanner.processFile(
+          `${fixture.path}/.claude/settings.json`,
+        );
+
+        expect(result).toBeTruthy();
+        expect(result?.type).toBe('settings-json');
+        expect(result?.path).toContain('settings.json');
+      } finally {
+        await fixture.rm();
+      }
+    });
+
+    test('should handle invalid JSON gracefully', async () => {
+      const scanner = new SettingsJsonScanner();
+
+      const fixture = await createFixture({
+        '.claude': {
+          'settings.json': '{ invalid json',
+        },
+      });
+
+      try {
+        const result = await scanner.processFile(
+          `${fixture.path}/.claude/settings.json`,
+        );
+
+        expect(result).toBeNull();
+      } finally {
+        await fixture.rm();
+      }
+    });
+
+    test('should handle large files', async () => {
+      const scanner = new SettingsJsonScanner();
+
+      // Create content larger than 1MB
+      const largeContent = JSON.stringify({
+        data: 'x'.repeat(1024 * 1024 + 1),
+      });
+
+      const fixture = await createFixture({
+        '.claude': {
+          'settings.json': largeContent,
+        },
+      });
+
+      try {
+        const result = await scanner.processFile(
+          `${fixture.path}/.claude/settings.json`,
+        );
+
+        // Should be null due to size limit
+        expect(result).toBeNull();
+      } finally {
+        await fixture.rm();
+      }
+    });
+  });
+
+  describe('scanSettingsJson', () => {
+    test('should scan multiple settings.json files', async () => {
+      const fixture = await createFixture({
+        project1: {
+          '.claude': {
+            'settings.json': JSON.stringify({ project: 'project1' }),
+            'settings.local.json': JSON.stringify({ local: true }),
+          },
+        },
+        project2: {
+          '.claude': {
+            'settings.json': JSON.stringify({ project: 'project2' }),
+          },
+        },
+      });
+
+      try {
+        const results = await scanSettingsJson({
+          path: fixture.path,
+          recursive: false, // Don't scan home directory in tests
+        });
+
+        expect(results).toHaveLength(3); // 2 settings.json + 1 settings.local.json
+        expect(
+          results.filter((file) => file.type === 'settings-json'),
+        ).toHaveLength(2);
+        expect(
+          results.filter((file) => file.type === 'settings-local-json'),
+        ).toHaveLength(1);
+      } finally {
+        await fixture.rm();
+      }
+    }, 10000); // Increase timeout
+  });
+}


### PR DESCRIPTION
## Summary
- Implements support for settings.json configuration files as requested in #9
- Adds detection for three types of settings files:
  - `.claude/settings.json` (project shared settings)
  - `.claude/settings.local.json` (local project settings, gitignored)
  - `~/.claude/settings.json` (global user settings)

## Changes
- Added `settings-json` and `settings-local-json` to ClaudeFileType enum
- Created SettingsJsonScanner with JSON validation
- Updated file detection to look for settings files in `.claude/` directories
- Enhanced UI with 3-level path display (e.g., `project-name/.claude/settings.json`)
- Added icons (⚙️ for settings.json, 🔧 for settings.local.json) and colors (cyan/yellowBright)
- Implemented JSON formatting in preview for better readability
- Updated documentation in README.md and CLAUDE.md

## Test plan
- [x] Settings files are correctly detected in `.claude/` directories
- [x] 3-level path display shows project context clearly
- [x] JSON files are formatted in preview
- [x] Build passes
- [x] TypeScript checks pass
- [x] No unused dependencies

Closes #9