### PR TITLE
chore: disable lefthook during bumpp releases to prevent CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "knip": "knip",
     "ci": "concurrently --kill-others-on-fail --success all -n \"build,check,typecheck,knip,test\" -c \"cyan,green,yellow,magenta,blue\" \"bun run build\" \"bun run check\" \"bun run typecheck\" \"bun run knip\" \"bun run test\"",
     "prepack": "bun run build && clean-pkg-json",
-    "release": "bun run check && bun run typecheck && bun run test && bun run build && bumpp"
+    "release": "bun run ci && LEFTHOOK=0 bumpp"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "knip": "knip",
     "ci": "concurrently --kill-others-on-fail --success all -n \"build,check,typecheck,knip,test\" -c \"cyan,green,yellow,magenta,blue\" \"bun run build\" \"bun run check\" \"bun run typecheck\" \"bun run knip\" \"bun run test\"",
     "prepack": "bun run build && clean-pkg-json",
-    "release": "bun run ci && LEFTHOOK=0 bumpp"
+    "release": "bun run ci && bumpp --no-verify"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",


### PR DESCRIPTION
## Summary
- Simplify release script to run CI once, then execute bumpp with lefthook disabled
- Prevents duplicate CI runs and potential failures during version commits

## Problem (AS-IS)
When running `bun run release`, the workflow was:
1. Individual CI checks run sequentially (check, typecheck, test, build)
2. bumpp creates a version commit
3. lefthook pre-commit hook triggers, running CI again
4. If CI fails on the version commit, the release process gets blocked

## Solution (TO-BE)
- Changed release script from: `bun run check && bun run typecheck && bun run test && bun run build && bumpp`
- To: `bun run ci && LEFTHOOK=0 bumpp`

## Why This Matters
- **Efficiency**: CI runs only once instead of twice
- **Reliability**: Version commits won't fail due to transient CI issues
- **Simplicity**: Single CI command instead of multiple sequential checks
- **Best Practice**: Follows Gemini's recommendation for release automation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release process to streamline multiple checks and builds into a single step, improving efficiency and reliability for releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->